### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "A cross-platform pseudoterminal implementation with async support
 version = "0.1.1"
 license = "MIT"
 edition = "2021"
+repository = "https://github.com/michaelvanstraten/pseudoterminal"
 
 [package.metadata.docs.rs]
 # document all features


### PR DESCRIPTION
to allow crates.is, rust-digger, and others to link to it

I build the Rust Digger to help Crate authors with some simple verifications.  [The list of your crates](https://rust-digger.code-maven.com/users/michaelvanstraten) to see which one does not have the repository link yet.  I hope it will help.